### PR TITLE
Add read/written bytes counter to Conn and update measurer

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.18.3"
+          go-version: "1.19.6"
       - uses: actions/checkout@v2
       - run: go test -race -v -coverprofile=msak.cov -coverpkg=./... ./...
       - uses: shogo82148/actions-goveralls@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        go: [ "1.18.2" ]
+        go: [ "1.19.6" ]
         os: [ "ubuntu-20.04", "windows-2019", "macos-10.15" ]
     steps:
       - uses: magnetikonline/action-golang-cache@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/m-lab/msak
 
-go 1.18
+go 1.19
 
 require (
 	github.com/getlantern/httptest v0.0.0-20161025015934-4b40f4c7e590

--- a/internal/measurer/measurer.go
+++ b/internal/measurer/measurer.go
@@ -17,8 +17,10 @@ import (
 )
 
 type ndt8Measurer struct {
-	connInfo  netx.ConnInfo
-	startTime time.Time
+	connInfo           netx.ConnInfo
+	startTime          time.Time
+	bytesReadOffset    uint64
+	bytesWrittenOffset uint64
 
 	dstChan chan model.Measurement
 }
@@ -39,10 +41,13 @@ func Start(ctx context.Context, conn net.Conn) <-chan model.Measurement {
 	dst := make(chan model.Measurement, 100)
 
 	connInfo := netx.ToConnInfo(conn)
+	read, written := connInfo.ByteCounters()
 	m := &ndt8Measurer{
-		connInfo:  connInfo,
-		dstChan:   dst,
-		startTime: time.Now(),
+		connInfo:           connInfo,
+		dstChan:            dst,
+		startTime:          time.Now(),
+		bytesReadOffset:    read,
+		bytesWrittenOffset: written,
 	}
 	go m.loop(ctx)
 	return dst
@@ -74,18 +79,27 @@ func (m *ndt8Measurer) loop(ctx context.Context) {
 func (m *ndt8Measurer) measure(ctx context.Context) {
 	// On non-Linux systems, collecting kernel metrics WILL fail. In that case,
 	// we still want to return a (empty) Measurement.
-
 	bbrInfo, tcpInfo, err := m.connInfo.Info()
 	if err != nil {
 		log.Printf("GetInfo() failed for context %p: %v", ctx, err)
 	}
 
+	// Read current bytes counters.
+	read, written := m.connInfo.ByteCounters()
+
 	select {
 	case <-ctx.Done():
 		// NOTHING
 	case m.dstChan <- model.Measurement{
-		ElapsedTime: time.Since(m.startTime).Microseconds(),
-		BBRInfo:     &bbrInfo,
+		ElapsedTime: uint64(time.Since(m.startTime).Microseconds()),
+		// Byte counters are offset by their initial value, so that the
+		// BytesSent/BytesReceived fields represent "application-level bytes
+		// sent/received over the connection since the beginning of the
+		// measurement" as precisely as possible. Note that this includes the
+		// WebSocket framing overhead.
+		BytesSent:     written - m.bytesWrittenOffset,
+		BytesReceived: read - m.bytesReadOffset,
+		BBRInfo:       &bbrInfo,
 		TCPInfo: &model.TCPInfo{
 			LinuxTCPInfo: tcpInfo,
 			ElapsedTime:  time.Since(m.connInfo.AcceptTime()).Microseconds(),

--- a/internal/measurer/measurer_test.go
+++ b/internal/measurer/measurer_test.go
@@ -3,10 +3,12 @@ package measurer_test
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/msak/internal/measurer"
 	"github.com/m-lab/msak/internal/netx"
 )
@@ -15,17 +17,27 @@ func TestNdt8Measurer_Start(t *testing.T) {
 	// Use a net.Pipe to test. This has the advantage that it works on every
 	// platform, allowing to test the measurer functionality on e.g. Windows,
 	// but TCPInfo/BBRInfo retrieval will never work.
-	client, _ := net.Pipe()
-
-	netxConn := &netx.Conn{
-		Conn: client,
+	client, server := net.Pipe()
+	serverConn := &netx.Conn{
+		Conn: server,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	mchan := measurer.Start(ctx, netxConn)
+	mchan := measurer.Start(ctx, serverConn)
+	go func() {
+		_, err := serverConn.Write([]byte("test"))
+		rtx.Must(err, "failed to write to pipe")
+		serverConn.Close()
+	}()
+	_, err := ioutil.ReadAll(client)
+	rtx.Must(err, "failed to read from pipe")
+
 	select {
-	case <-mchan:
+	case m := <-mchan:
 		fmt.Println("received measurement")
+		if m.BytesSent != 4 {
+			t.Errorf("invalid byte counter value")
+		}
 	case <-time.After(1 * time.Second):
 		t.Fatalf("did not receive any measurement")
 	}

--- a/pkg/ndt8/model/measurement.go
+++ b/pkg/ndt8/model/measurement.go
@@ -26,15 +26,15 @@ type WireMeasurement struct {
 type Measurement struct {
 	// BytesSent is the number of bytes sent at the application level by the
 	// party sending this Measurement.
-	BytesSent int64 `json:",omitempty"`
+	BytesSent uint64 `json:",omitempty"`
 
 	// BytesReceived is the number of bytes received at the application level
 	// by the party sending this Measurement.
-	BytesReceived int64 `json:",omitempty"`
+	BytesReceived uint64 `json:",omitempty"`
 
 	// ElapsedTime is the time elapsed since the start of the measurement
 	// according to the party sending this Measurement.
-	ElapsedTime int64 `json:",omitempty"`
+	ElapsedTime uint64 `json:",omitempty"`
 
 	// BBRInfo is an optional struct containing BBR metrics. Only applicable
 	// when the congestion control algorithm used by the party sending this

--- a/pkg/ndt8/model/measurement.go
+++ b/pkg/ndt8/model/measurement.go
@@ -26,15 +26,15 @@ type WireMeasurement struct {
 type Measurement struct {
 	// BytesSent is the number of bytes sent at the application level by the
 	// party sending this Measurement.
-	BytesSent uint64 `json:",omitempty"`
+	BytesSent int64 `json:",omitempty"`
 
 	// BytesReceived is the number of bytes received at the application level
 	// by the party sending this Measurement.
-	BytesReceived uint64 `json:",omitempty"`
+	BytesReceived int64 `json:",omitempty"`
 
 	// ElapsedTime is the time elapsed since the start of the measurement
 	// according to the party sending this Measurement.
-	ElapsedTime uint64 `json:",omitempty"`
+	ElapsedTime int64 `json:",omitempty"`
 
 	// BBRInfo is an optional struct containing BBR metrics. Only applicable
 	// when the congestion control algorithm used by the party sending this


### PR DESCRIPTION
This PR adds counters for read/written bytes to `netx.Conn` and updates the measurer package to use them to populate `Measurement.BytesSent` and `Measurement.BytesReceived`. 

The main reasons for this change are:
1. Since the measurements channel is buffered, letting the reader fill in its own application-level byte counters meant that there would be a discrepancy (in extreme cases, several seconds long) between the time when the `measurer` queues a new `Measurement` and the time the application-level byte counters are added by the reader. This is avoided by letting the measurer return a fully populated `Measurement` struct that can be directly sent over the wire, even if late.
2. The WebSocket overhead wasn't considered (AFAIK) in the previous NDT implementation, nor was TLS. This method attempts to measure the TCP payload size more precisely.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/6)
<!-- Reviewable:end -->
