### PR TITLE
Add utility functions to netx for saving a UUID in a Context

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -174,14 +174,7 @@ func (h *Handler) upgradeAndRunMeasurement(kind model.TestDirection, rw http.Res
 		}
 	}
 
-	uuid, err := conn.UUID()
-	if err != nil {
-		// UUID() has a fallback that won't ever fail. This should not happen.
-		log.Error("Failed to read UUID", "ctx",
-			fmt.Sprintf("%p", req.Context()), "error", err)
-		wsConn.Close()
-		return
-	}
+	uuid := conn.UUID()
 	archivalData := model.Throughput1Result{
 		MeasurementID:  mid,
 		UUID:           uuid,

--- a/internal/netx/conn.go
+++ b/internal/netx/conn.go
@@ -1,6 +1,7 @@
 package netx
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -16,6 +17,10 @@ import (
 	"github.com/m-lab/tcp-info/tcp"
 	"github.com/m-lab/uuid"
 )
+
+type contextKey string
+
+const uuidCtxKey = "netx-uuid"
 
 // ConnInfo provides operations on a net.Conn's underlying file descriptor.
 type ConnInfo interface {
@@ -119,4 +124,21 @@ func (c *Conn) UUID() (string, error) {
 		uuid = gid.String()
 	}
 	return uuid, nil
+}
+
+// SaveUUID saves this connection's UUID in a context.Context using a globally
+// unique key. LoadUUID should be used to retrieve the uuid from the context.
+func (c *Conn) SaveUUID(ctx context.Context) context.Context {
+	uuid, _ := c.UUID()
+	return context.WithValue(ctx, contextKey(uuidCtxKey), uuid)
+}
+
+// LoadUUID reads a connection UUID from a context.Context using a globally
+// unique key. Returns an empty string if the UUID is not found in the context.
+func LoadUUID(ctx context.Context) string {
+	uuid, ok := ctx.Value(contextKey(uuidCtxKey)).(string)
+	if !ok {
+		return ""
+	}
+	return uuid
 }

--- a/internal/netx/conn.go
+++ b/internal/netx/conn.go
@@ -27,7 +27,7 @@ type ConnInfo interface {
 	ByteCounters() (uint64, uint64)
 	Info() (inetdiag.BBRInfo, tcp.LinuxTCPInfo, error)
 	AcceptTime() time.Time
-	UUID() (string, error)
+	UUID() string
 	GetCC() (string, error)
 	SetCC(string) error
 	SaveUUID(context.Context) context.Context
@@ -115,7 +115,7 @@ func (c *Conn) AcceptTime() time.Time {
 
 // UUID returns an M-Lab UUID. On platforms not supporting SO_COOKIE, it
 // returns a google/uuid as a fallback. If the fallback fails, it panics.
-func (c *Conn) UUID() (string, error) {
+func (c *Conn) UUID() string {
 	uuid, err := uuid.FromFile(c.fp)
 	if err != nil {
 		// fallback: use google/uuid if the platform does not support SO_COOKIE.
@@ -124,14 +124,13 @@ func (c *Conn) UUID() (string, error) {
 		rtx.Must(err, "unable to fallback to uuid")
 		uuid = gid.String()
 	}
-	return uuid, nil
+	return uuid
 }
 
 // SaveUUID saves this connection's UUID in a context.Context using a globally
 // unique key. LoadUUID should be used to retrieve the uuid from the context.
 func (c *Conn) SaveUUID(ctx context.Context) context.Context {
-	uuid, _ := c.UUID()
-	return context.WithValue(ctx, contextKey(uuidCtxKey), uuid)
+	return context.WithValue(ctx, contextKey(uuidCtxKey), c.UUID())
 }
 
 // LoadUUID reads a connection UUID from a context.Context using a globally

--- a/internal/netx/conn.go
+++ b/internal/netx/conn.go
@@ -30,6 +30,7 @@ type ConnInfo interface {
 	UUID() (string, error)
 	GetCC() (string, error)
 	SetCC(string) error
+	SaveUUID(context.Context) context.Context
 }
 
 // ToConnInfo is a helper function to convert a net.Conn into a netx.ConnInfo.

--- a/internal/netx/listener_linux_test.go
+++ b/internal/netx/listener_linux_test.go
@@ -109,9 +109,6 @@ func TestConn_GetInfoAndUUID(t *testing.T) {
 	if c, ok = got.(netx.ConnInfo); !ok {
 		t.Fatalf("Listener.Accept() wrong Conn type = %T, want netx.Conn", got)
 	}
-	if _, err := c.UUID(); err != nil {
-		t.Errorf("GetUUID failed: %v", err)
-	}
 	if _, _, err = c.Info(); err != nil {
 		t.Fatalf("GetInfo failed: %v", err)
 	}
@@ -232,7 +229,7 @@ func TestSaveAndLoadCtx(t *testing.T) {
 	}
 
 	// Check that the UUID is saved to the context.
-	expected, _ := c.UUID()
+	expected := c.UUID()
 	ctx := c.SaveUUID(context.Background())
 	actual := netx.LoadUUID(ctx)
 	if actual != expected {

--- a/pkg/throughput1/protocol.go
+++ b/pkg/throughput1/protocol.go
@@ -286,10 +286,7 @@ func (p *Protocol) createWireMeasurement(ctx context.Context) model.WireMeasurem
 		log.Printf("failed to read cc (ctx %p): %v\n",
 			ctx, err)
 	}
-	uuid, err := p.connInfo.UUID()
-	if err != nil {
-		log.Printf("failed to get UUID (ctx %p): %v\n", ctx, err)
-	}
+	uuid := p.connInfo.UUID()
 	wm.CC = cc
 	wm.UUID = uuid
 	return wm


### PR DESCRIPTION
This PR adds a method to `netx.ConnInfo` and a `netx.LoadUUID` utility function to save and load a UUID to/from a `context.Context`. This is so that the context key is unique across all packages, being a custom type in `netx`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/17)
<!-- Reviewable:end -->
