### PR TITLE
Add UUID to latency1 model

### DIFF
--- a/cmd/msak-server/server.go
+++ b/cmd/msak-server/server.go
@@ -39,7 +39,11 @@ func init() {
 	flag.StringVar(&tokenMachine, "token.machine", "", "Use given machine name to verify token claims")
 }
 
-// httpServer creates a new *http.Server with explicit Read and Write timeouts.
+// httpServer creates a new *http.Server with explicit Read and Write
+// timeouts, the provided address and handler, and an empty TLS configuration.
+//
+// This server can only be used with a net.Listener that returns netx.ConnInfo
+// after accepting a new connection.
 func httpServer(addr string, handler http.Handler) *http.Server {
 	tlsconf := &tls.Config{}
 	return &http.Server{
@@ -52,6 +56,9 @@ func httpServer(addr string, handler http.Handler) *http.Server {
 		// servers.
 		ReadTimeout:  time.Minute,
 		WriteTimeout: time.Minute,
+		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+			return netx.ToConnInfo(c).SaveUUID(ctx)
+		},
 	}
 }
 

--- a/cmd/msak-server/server.go
+++ b/cmd/msak-server/server.go
@@ -46,7 +46,7 @@ func init() {
 // after accepting a new connection.
 func httpServer(addr string, handler http.Handler) *http.Server {
 	tlsconf := &tls.Config{}
-	return &http.Server{
+	s := &http.Server{
 		Addr:      addr,
 		Handler:   handler,
 		TLSConfig: tlsconf,
@@ -60,6 +60,8 @@ func httpServer(addr string, handler http.Handler) *http.Server {
 			return netx.ToConnInfo(c).SaveUUID(ctx)
 		},
 	}
+	s.SetKeepAlivesEnabled(false)
+	return s
 }
 
 func main() {

--- a/internal/latency1/latency1.go
+++ b/internal/latency1/latency1.go
@@ -91,7 +91,7 @@ func (h *Handler) Authorize(rw http.ResponseWriter, req *http.Request) {
 	h.sessions.Set(mid, session, ttlcache.DefaultTTL)
 	h.sessionsMu.Unlock()
 
-	log.Debug("session created", "id", mid)
+	log.Debug("session created", "id", mid, "uuid", uuid)
 
 	// Create a valid kickoff packet for this session and send it in the
 	// response body.

--- a/internal/latency1/latency1_test.go
+++ b/internal/latency1/latency1_test.go
@@ -135,8 +135,8 @@ func TestHandler_Result(t *testing.T) {
 	if err != nil {
 		t.Errorf("cannot unmarshal response body: %v", err)
 	}
-	if summary.ID != "test" {
-		t.Errorf("invalid ID in summary")
+	if summary.ID == "" {
+		t.Errorf("empty ID in summary")
 	}
 
 	// Do not provide any mid.

--- a/internal/latency1/latency1_test.go
+++ b/internal/latency1/latency1_test.go
@@ -1,6 +1,7 @@
 package latency1
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/m-lab/msak/internal/netx"
 	"github.com/m-lab/msak/pkg/latency1/model"
 )
 
@@ -67,7 +69,10 @@ func TestHandler_Authorize(t *testing.T) {
 	h := NewHandler(tempDir, 5*time.Second)
 
 	rw := httptest.NewRecorder()
-	req, err := http.NewRequest(http.MethodGet, "/latency/v1/authorize", nil)
+	conn := netx.Conn{}
+	ctx := conn.SaveUUID(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"/latency/v1/authorize", nil)
 	if err != nil {
 		t.Fatalf("cannot create request: %v", err)
 	}
@@ -94,7 +99,10 @@ func TestHandler_Result(t *testing.T) {
 	tempDir := t.TempDir()
 	h := NewHandler(tempDir, 5*time.Second)
 	rw := httptest.NewRecorder()
-	req, err := http.NewRequest(http.MethodGet, "/latency/v1/authorize", nil)
+	conn := netx.Conn{}
+	ctx := conn.SaveUUID(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"/latency/v1/authorize", nil)
 	if err != nil {
 		t.Fatalf("cannot create request: %v", err)
 	}

--- a/pkg/latency1/model/result.go
+++ b/pkg/latency1/model/result.go
@@ -71,9 +71,6 @@ type RoundTrip struct {
 // Session is the in-memory structure holding information about a UDP latency
 // measurement session.
 type Session struct {
-	// ID is the unique identifier for this latency measurement.
-	ID string
-
 	// UUID is the unique identifier of the TCP connection that started
 	// this latency measurement.
 	UUID string
@@ -134,9 +131,9 @@ type Summary struct {
 }
 
 // NewSession returns an empty Session with all the fields initialized.
-func NewSession(id string) *Session {
+func NewSession(uuid string) *Session {
 	return &Session{
-		ID:        id,
+		UUID:      uuid,
 		StartTime: time.Now(),
 
 		Started: false,
@@ -152,8 +149,7 @@ func NewSession(id string) *Session {
 // Archive converts this Session to ArchivalData.
 func (s *Session) Archive() *ArchivalData {
 	return &ArchivalData{
-		ID:              s.ID,
-		UUID:            s.UUID,
+		ID:              s.UUID,
 		GitShortCommit:  prometheusx.GitShortCommit,
 		Version:         "TODO",
 		Client:          s.Client,
@@ -168,7 +164,7 @@ func (s *Session) Archive() *ArchivalData {
 // Summarize converts this Session to a Summary.
 func (s *Session) Summarize() *Summary {
 	return &Summary{
-		ID:              s.ID,
+		ID:              s.UUID,
 		StartTime:       s.StartTime,
 		PacketsSent:     len(s.SendTimes),
 		PacketsReceived: s.PacketsReceived(),

--- a/pkg/latency1/model/result.go
+++ b/pkg/latency1/model/result.go
@@ -33,6 +33,10 @@ type ArchivalData struct {
 	// ID is the unique identifier for this latency measurement.
 	ID string
 
+	// UUID is the unique identifier of the TCP connection that started this
+	// latency measurement.
+	UUID string
+
 	// Client is the client's ip:port pair.
 	Client string
 	// Server is the server's ip:port pair.
@@ -69,6 +73,11 @@ type RoundTrip struct {
 type Session struct {
 	// ID is the unique identifier for this latency measurement.
 	ID string
+
+	// UUID is the unique identifier of the TCP connection that started
+	// this latency measurement.
+	UUID string
+
 	// StartTime is the test's start time.
 	StartTime time.Time
 	// EndTime is the test's end time.
@@ -144,6 +153,7 @@ func NewSession(id string) *Session {
 func (s *Session) Archive() *ArchivalData {
 	return &ArchivalData{
 		ID:              s.ID,
+		UUID:            s.UUID,
 		GitShortCommit:  prometheusx.GitShortCommit,
 		Version:         "TODO",
 		Client:          s.Client,


### PR DESCRIPTION
This PR uses the mechanism introduced in #17 to save the UUID of each incoming HTTP connection in the request's context. Then, the UUID is retrieved from latency1's  `/authorize` handler, added to the in-memory session and eventually to the archival data. 

This establishes a link between the UDP-based latency1 measurement and the TCP connection that started it, and allows joining the latency1 data with uuid-annotator's annotations in BigQuery.

Stacked on top of #17.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/18)
<!-- Reviewable:end -->
