### PR TITLE
Add latency1 handlers and UDP server to msak-server

### DIFF
--- a/cmd/msak-server/server.go
+++ b/cmd/msak-server/server.go
@@ -15,7 +15,9 @@ import (
 	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/msak/internal/handler"
+	"github.com/m-lab/msak/internal/latency1"
 	"github.com/m-lab/msak/internal/netx"
+	latency1spec "github.com/m-lab/msak/pkg/latency1/spec"
 	"github.com/m-lab/msak/pkg/throughput1/spec"
 )
 
@@ -25,9 +27,12 @@ var (
 	flagEndpoint          = flag.String("wss_addr", ":4443", "Listen address/port for TLS connections")
 	flagEndpointCleartext = flag.String("ws_addr", ":8080", "Listen address/port for cleartext connections")
 	flagDataDir           = flag.String("datadir", "./data", "Directory to store data in")
-	tokenVerifyKey        = flagx.FileBytesArray{}
-	tokenVerify           bool
-	tokenMachine          string
+	flagLatencyEndpoint   = flag.String("latency_addr", ":1053", "Listen address/port for UDP latency tests")
+	flagLatencyTTL        = flag.Duration("latency_ttl",
+		latency1spec.DefaultSessionCacheTTL, "Session cache's TTL")
+	tokenVerifyKey = flagx.FileBytesArray{}
+	tokenVerify    bool
+	tokenMachine   string
 
 	// Context for the whole program.
 	ctx, cancel = context.WithCancel(context.Background())
@@ -91,13 +96,19 @@ func main() {
 	acm, _ := controller.Setup(ctx, v, tokenVerify, tokenMachine,
 		throughput1TxPaths, throughput1TokenPaths)
 
-	throughput1Mux := http.NewServeMux()
+	mux := http.NewServeMux()
+	latency1Handler := latency1.NewHandler(*flagDataDir, *flagLatencyTTL)
 	throughput1Handler := handler.New(*flagDataDir)
-	throughput1Mux.Handle(spec.DownloadPath, http.HandlerFunc(throughput1Handler.Download))
-	throughput1Mux.Handle(spec.UploadPath, http.HandlerFunc(throughput1Handler.Upload))
+
+	mux.Handle(spec.DownloadPath, http.HandlerFunc(throughput1Handler.Download))
+	mux.Handle(spec.UploadPath, http.HandlerFunc(throughput1Handler.Upload))
+	mux.Handle(latency1spec.AuthorizeV1, http.HandlerFunc(
+		latency1Handler.Authorize))
+	mux.Handle(latency1spec.ResultV1, http.HandlerFunc(
+		latency1Handler.Result))
 	throughput1ServerCleartext := httpServer(
 		*flagEndpointCleartext,
-		acm.Then(throughput1Mux))
+		acm.Then(mux))
 
 	log.Info("About to listen for ws tests", "endpoint", *flagEndpointCleartext)
 
@@ -116,7 +127,7 @@ func main() {
 	if *flagCertFile != "" && *flagKeyFile != "" {
 		throughput1Server := httpServer(
 			*flagEndpoint,
-			acm.Then(throughput1Mux))
+			acm.Then(mux))
 		log.Info("About to listen for wss tests", "endpoint", *flagEndpoint)
 
 		tcpl, err := net.Listen("tcp", throughput1Server.Addr)
@@ -130,6 +141,15 @@ func main() {
 			defer throughput1Server.Close()
 		}()
 	}
+
+	// Start a UDP server for latency measurements.
+	addr, err := net.ResolveUDPAddr("udp", *flagLatencyEndpoint)
+	rtx.Must(err, "failed to resolve latency endpoint address")
+	udpServer, err := net.ListenUDP("udp", addr)
+	rtx.Must(err, "cannot start latency UDP server")
+	defer udpServer.Close()
+
+	go latency1Handler.ProcessPacketLoop(udpServer)
 
 	<-ctx.Done()
 	cancel()

--- a/cmd/msak-server/server.go
+++ b/cmd/msak-server/server.go
@@ -145,11 +145,11 @@ func main() {
 	// Start a UDP server for latency measurements.
 	addr, err := net.ResolveUDPAddr("udp", *flagLatencyEndpoint)
 	rtx.Must(err, "failed to resolve latency endpoint address")
-	udpServer, err := net.ListenUDP("udp", addr)
+	udpListener, err := net.ListenUDP("udp", addr)
 	rtx.Must(err, "cannot start latency UDP server")
-	defer udpServer.Close()
+	defer udpListener.Close()
 
-	go latency1Handler.ProcessPacketLoop(udpServer)
+	go latency1Handler.ProcessPacketLoop(udpListener)
 
 	<-ctx.Done()
 	cancel()

--- a/cmd/msak-server/server.go
+++ b/cmd/msak-server/server.go
@@ -39,7 +39,11 @@ func init() {
 	flag.StringVar(&tokenMachine, "token.machine", "", "Use given machine name to verify token claims")
 }
 
-// httpServer creates a new *http.Server with explicit Read and Write timeouts.
+// httpServer creates a new *http.Server with explicit Read and Write
+// timeouts, the provided address and handler, and an empty TLS configuration.
+//
+// This server can only be used with a net.Listener that returns netx.ConnInfo
+// after accepting a new connection.
 func httpServer(addr string, handler http.Handler) *http.Server {
 	tlsconf := &tls.Config{}
 	return &http.Server{
@@ -52,6 +56,9 @@ func httpServer(addr string, handler http.Handler) *http.Server {
 		// servers.
 		ReadTimeout:  time.Minute,
 		WriteTimeout: time.Minute,
+		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+			return netx.ToConnInfo(c).SaveUUID(ctx)
+		},
 	}
 }
 

--- a/cmd/msak-server/server.go
+++ b/cmd/msak-server/server.go
@@ -46,7 +46,7 @@ func init() {
 // after accepting a new connection.
 func httpServer(addr string, handler http.Handler) *http.Server {
 	tlsconf := &tls.Config{}
-	return &http.Server{
+	s := &http.Server{
 		Addr:      addr,
 		Handler:   handler,
 		TLSConfig: tlsconf,
@@ -60,6 +60,8 @@ func httpServer(addr string, handler http.Handler) *http.Server {
 			return netx.ToConnInfo(c).SaveUUID(ctx)
 		},
 	}
+	s.SetKeepAlivesEnabled(false)
+	return s
 }
 
 func main() {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -174,14 +174,7 @@ func (h *Handler) upgradeAndRunMeasurement(kind model.TestDirection, rw http.Res
 		}
 	}
 
-	uuid, err := conn.UUID()
-	if err != nil {
-		// UUID() has a fallback that won't ever fail. This should not happen.
-		log.Error("Failed to read UUID", "ctx",
-			fmt.Sprintf("%p", req.Context()), "error", err)
-		wsConn.Close()
-		return
-	}
+	uuid := conn.UUID()
 	archivalData := model.Throughput1Result{
 		MeasurementID:  mid,
 		UUID:           uuid,

--- a/internal/latency1/latency1.go
+++ b/internal/latency1/latency1.go
@@ -91,7 +91,7 @@ func (h *Handler) Authorize(rw http.ResponseWriter, req *http.Request) {
 	h.sessions.Set(mid, session, ttlcache.DefaultTTL)
 	h.sessionsMu.Unlock()
 
-	log.Debug("session created", "id", mid)
+	log.Debug("session created", "id", mid, "uuid", uuid)
 
 	// Create a valid kickoff packet for this session and send it in the
 	// response body.

--- a/internal/latency1/latency1_test.go
+++ b/internal/latency1/latency1_test.go
@@ -135,8 +135,8 @@ func TestHandler_Result(t *testing.T) {
 	if err != nil {
 		t.Errorf("cannot unmarshal response body: %v", err)
 	}
-	if summary.ID != "test" {
-		t.Errorf("invalid ID in summary")
+	if summary.ID == "" {
+		t.Errorf("empty ID in summary")
 	}
 
 	// Do not provide any mid.

--- a/internal/latency1/latency1_test.go
+++ b/internal/latency1/latency1_test.go
@@ -1,6 +1,7 @@
 package latency1
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
+	"github.com/m-lab/msak/internal/netx"
 	"github.com/m-lab/msak/pkg/latency1/model"
 )
 
@@ -67,7 +69,10 @@ func TestHandler_Authorize(t *testing.T) {
 	h := NewHandler(tempDir, 5*time.Second)
 
 	rw := httptest.NewRecorder()
-	req, err := http.NewRequest(http.MethodGet, "/latency/v1/authorize", nil)
+	conn := netx.Conn{}
+	ctx := conn.SaveUUID(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"/latency/v1/authorize", nil)
 	if err != nil {
 		t.Fatalf("cannot create request: %v", err)
 	}
@@ -94,7 +99,10 @@ func TestHandler_Result(t *testing.T) {
 	tempDir := t.TempDir()
 	h := NewHandler(tempDir, 5*time.Second)
 	rw := httptest.NewRecorder()
-	req, err := http.NewRequest(http.MethodGet, "/latency/v1/authorize", nil)
+	conn := netx.Conn{}
+	ctx := conn.SaveUUID(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"/latency/v1/authorize", nil)
 	if err != nil {
 		t.Fatalf("cannot create request: %v", err)
 	}

--- a/internal/netx/conn.go
+++ b/internal/netx/conn.go
@@ -1,6 +1,7 @@
 package netx
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -16,6 +17,10 @@ import (
 	"github.com/m-lab/tcp-info/tcp"
 	"github.com/m-lab/uuid"
 )
+
+type contextKey string
+
+const uuidCtxKey = "netx-uuid"
 
 // ConnInfo provides operations on a net.Conn's underlying file descriptor.
 type ConnInfo interface {
@@ -119,4 +124,21 @@ func (c *Conn) UUID() (string, error) {
 		uuid = gid.String()
 	}
 	return uuid, nil
+}
+
+// SaveUUID saves this connection's UUID in a context.Context using a globally
+// unique key. LoadUUID should be used to retrieve the uuid from the context.
+func (c *Conn) SaveUUID(ctx context.Context) context.Context {
+	uuid, _ := c.UUID()
+	return context.WithValue(ctx, contextKey(uuidCtxKey), uuid)
+}
+
+// LoadUUID reads a connection UUID from a context.Context using a globally
+// unique key. Returns an empty string if the UUID is not found in the context.
+func LoadUUID(ctx context.Context) string {
+	uuid, ok := ctx.Value(contextKey(uuidCtxKey)).(string)
+	if !ok {
+		return ""
+	}
+	return uuid
 }

--- a/internal/netx/conn.go
+++ b/internal/netx/conn.go
@@ -27,7 +27,7 @@ type ConnInfo interface {
 	ByteCounters() (uint64, uint64)
 	Info() (inetdiag.BBRInfo, tcp.LinuxTCPInfo, error)
 	AcceptTime() time.Time
-	UUID() (string, error)
+	UUID() string
 	GetCC() (string, error)
 	SetCC(string) error
 	SaveUUID(context.Context) context.Context
@@ -115,7 +115,7 @@ func (c *Conn) AcceptTime() time.Time {
 
 // UUID returns an M-Lab UUID. On platforms not supporting SO_COOKIE, it
 // returns a google/uuid as a fallback. If the fallback fails, it panics.
-func (c *Conn) UUID() (string, error) {
+func (c *Conn) UUID() string {
 	uuid, err := uuid.FromFile(c.fp)
 	if err != nil {
 		// fallback: use google/uuid if the platform does not support SO_COOKIE.
@@ -124,14 +124,13 @@ func (c *Conn) UUID() (string, error) {
 		rtx.Must(err, "unable to fallback to uuid")
 		uuid = gid.String()
 	}
-	return uuid, nil
+	return uuid
 }
 
 // SaveUUID saves this connection's UUID in a context.Context using a globally
 // unique key. LoadUUID should be used to retrieve the uuid from the context.
 func (c *Conn) SaveUUID(ctx context.Context) context.Context {
-	uuid, _ := c.UUID()
-	return context.WithValue(ctx, contextKey(uuidCtxKey), uuid)
+	return context.WithValue(ctx, contextKey(uuidCtxKey), c.UUID())
 }
 
 // LoadUUID reads a connection UUID from a context.Context using a globally

--- a/internal/netx/conn.go
+++ b/internal/netx/conn.go
@@ -30,6 +30,7 @@ type ConnInfo interface {
 	UUID() (string, error)
 	GetCC() (string, error)
 	SetCC(string) error
+	SaveUUID(context.Context) context.Context
 }
 
 // ToConnInfo is a helper function to convert a net.Conn into a netx.ConnInfo.

--- a/internal/netx/listener_linux_test.go
+++ b/internal/netx/listener_linux_test.go
@@ -109,9 +109,6 @@ func TestConn_GetInfoAndUUID(t *testing.T) {
 	if c, ok = got.(netx.ConnInfo); !ok {
 		t.Fatalf("Listener.Accept() wrong Conn type = %T, want netx.Conn", got)
 	}
-	if _, err := c.UUID(); err != nil {
-		t.Errorf("GetUUID failed: %v", err)
-	}
 	if _, _, err = c.Info(); err != nil {
 		t.Fatalf("GetInfo failed: %v", err)
 	}
@@ -232,7 +229,7 @@ func TestSaveAndLoadCtx(t *testing.T) {
 	}
 
 	// Check that the UUID is saved to the context.
-	expected, _ := c.UUID()
+	expected := c.UUID()
 	ctx := c.SaveUUID(context.Background())
 	actual := netx.LoadUUID(ctx)
 	if actual != expected {

--- a/pkg/latency1/model/result.go
+++ b/pkg/latency1/model/result.go
@@ -71,9 +71,6 @@ type RoundTrip struct {
 // Session is the in-memory structure holding information about a UDP latency
 // measurement session.
 type Session struct {
-	// ID is the unique identifier for this latency measurement.
-	ID string
-
 	// UUID is the unique identifier of the TCP connection that started
 	// this latency measurement.
 	UUID string
@@ -134,9 +131,9 @@ type Summary struct {
 }
 
 // NewSession returns an empty Session with all the fields initialized.
-func NewSession(id string) *Session {
+func NewSession(uuid string) *Session {
 	return &Session{
-		ID:        id,
+		UUID:      uuid,
 		StartTime: time.Now(),
 
 		Started: false,
@@ -152,8 +149,7 @@ func NewSession(id string) *Session {
 // Archive converts this Session to ArchivalData.
 func (s *Session) Archive() *ArchivalData {
 	return &ArchivalData{
-		ID:              s.ID,
-		UUID:            s.UUID,
+		ID:              s.UUID,
 		GitShortCommit:  prometheusx.GitShortCommit,
 		Version:         "TODO",
 		Client:          s.Client,
@@ -168,7 +164,7 @@ func (s *Session) Archive() *ArchivalData {
 // Summarize converts this Session to a Summary.
 func (s *Session) Summarize() *Summary {
 	return &Summary{
-		ID:              s.ID,
+		ID:              s.UUID,
 		StartTime:       s.StartTime,
 		PacketsSent:     len(s.SendTimes),
 		PacketsReceived: s.PacketsReceived(),

--- a/pkg/latency1/model/result.go
+++ b/pkg/latency1/model/result.go
@@ -33,6 +33,10 @@ type ArchivalData struct {
 	// ID is the unique identifier for this latency measurement.
 	ID string
 
+	// UUID is the unique identifier of the TCP connection that started this
+	// latency measurement.
+	UUID string
+
 	// Client is the client's ip:port pair.
 	Client string
 	// Server is the server's ip:port pair.
@@ -69,6 +73,11 @@ type RoundTrip struct {
 type Session struct {
 	// ID is the unique identifier for this latency measurement.
 	ID string
+
+	// UUID is the unique identifier of the TCP connection that started
+	// this latency measurement.
+	UUID string
+
 	// StartTime is the test's start time.
 	StartTime time.Time
 	// EndTime is the test's end time.
@@ -144,6 +153,7 @@ func NewSession(id string) *Session {
 func (s *Session) Archive() *ArchivalData {
 	return &ArchivalData{
 		ID:              s.ID,
+		UUID:            s.UUID,
 		GitShortCommit:  prometheusx.GitShortCommit,
 		Version:         "TODO",
 		Client:          s.Client,

--- a/pkg/latency1/spec/spec.go
+++ b/pkg/latency1/spec/spec.go
@@ -1,0 +1,13 @@
+package spec
+
+import "time"
+
+const (
+	// AuthorizeV1 is the v1 /authorize endpoint.
+	AuthorizeV1 = "/latency/v1/authorize"
+	// ResultV1 is the v1 /result endpoint.
+	ResultV1 = "/latency/v1/result"
+
+	// DefaultSessionCacheTTL is the default session cache TTL.
+	DefaultSessionCacheTTL = 1 * time.Minute
+)

--- a/pkg/throughput1/protocol.go
+++ b/pkg/throughput1/protocol.go
@@ -286,10 +286,7 @@ func (p *Protocol) createWireMeasurement(ctx context.Context) model.WireMeasurem
 		log.Printf("failed to read cc (ctx %p): %v\n",
 			ctx, err)
 	}
-	uuid, err := p.connInfo.UUID()
-	if err != nil {
-		log.Printf("failed to get UUID (ctx %p): %v\n", ctx, err)
-	}
+	uuid := p.connInfo.UUID()
 	wm.CC = cc
 	wm.UUID = uuid
 	return wm


### PR DESCRIPTION
This PR adds the handlers for `/latency/v1/authorize` and `/latency/v1/result` and starts the UDP server's main loop to process incoming packets.

Stacked on top of #18 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/19)
<!-- Reviewable:end -->
