### PR TITLE
Update workflow to use macos-12 and ubuntu 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         go: [ "1.20.2" ]
-        os: [ "ubuntu-20.04", "windows-2019", "macos-10.15" ]
+        os: [ "ubuntu-22.04", "windows-2019", "macos-12" ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/m-lab/msak
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/bigquery v1.51.1
@@ -10,6 +10,7 @@ require (
 	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/m-lab/access v0.0.11
 	github.com/m-lab/go v0.1.58
+	github.com/m-lab/locate v0.11.0
 	github.com/m-lab/ndt-server v0.20.17
 	github.com/m-lab/tcp-info v1.5.3
 	github.com/m-lab/uuid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,7 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gomodule/redigo v1.8.8 h1:f6cXq6RRfiyrOJEV7p3JhLDlmawGBVBBP1MggY8Mo4E=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v2.0.8+incompatible h1:ivUb1cGomAB101ZM1T0nOiWz9pSrTMoa9+EiY7igmkM=
@@ -232,6 +233,8 @@ github.com/m-lab/access v0.0.11 h1:i2aoal7zgdzXAA7pGL5mXpM8yybURDJGZLwBMmA4Le8=
 github.com/m-lab/access v0.0.11/go.mod h1:ky+hXvIDE1VgEdWhMRJLjYonRrcvfiEJ1BEZtK6+zFQ=
 github.com/m-lab/go v0.1.58 h1:Byow2/BmhoKy6+0hHMx5WxZiD7lF7fQcnEMtaHNxkC0=
 github.com/m-lab/go v0.1.58/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
+github.com/m-lab/locate v0.11.0 h1:9lU4nMSu1tlLk/q5G9hgPABuk5R/CG/jrQOv5RPnrFM=
+github.com/m-lab/locate v0.11.0/go.mod h1:yDjn89hHiOkFTxPaTIEvFDoT8ctZZBqwTTpU6TQpHYc=
 github.com/m-lab/ndt-server v0.20.17 h1:gTgHBbBgrpcyaZVGik84LIXYxHItDpvGZLnfOOs+zKA=
 github.com/m-lab/ndt-server v0.20.17/go.mod h1:NQyIilZvNVU3+EPYKmZWuZ2mHOPVwqD7c1gEPtkb+MA=
 github.com/m-lab/tcp-info v1.5.3 h1:4IspTPcNc8D8LNRvuFnID8gDiz+hxPAtYvpKZaiGGe8=


### PR DESCRIPTION
This PR updates the configuration of GH Actions workflows to use a more recent version of MacOS and Ubuntu. Also, updates go.mod to Go 1.20 to keep it in sync with the version used for testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/20)
<!-- Reviewable:end -->
