### PR TITLE
Send session ID in packets instead of UUID

### DIFF
--- a/internal/latency1/latency1.go
+++ b/internal/latency1/latency1.go
@@ -156,7 +156,7 @@ func (h *Handler) Result(rw http.ResponseWriter, req *http.Request) {
 // sendLoop sends UDP pings with progressive sequence numbers until the context
 // expires or is canceled.
 func (h *Handler) sendLoop(ctx context.Context, conn net.PacketConn,
-	remoteAddr net.Addr, session *model.Session, duration time.Duration) error {
+	remoteAddr net.Addr, id string, session *model.Session, duration time.Duration) error {
 	seq := 0
 	var err error
 
@@ -165,7 +165,7 @@ func (h *Handler) sendLoop(ctx context.Context, conn net.PacketConn,
 
 	memoryless.Run(timeout, func() {
 		b, marshalErr := json.Marshal(&model.LatencyPacket{
-			ID:      session.UUID,
+			ID:      id,
 			Type:    "s2c",
 			Seq:     seq,
 			LastRTT: int(session.LastRTT.Load()),
@@ -272,7 +272,7 @@ func (h *Handler) processPacket(conn net.PacketConn, remoteAddr net.Addr,
 			session.Started = true
 			session.Client = remoteAddr.String()
 			session.Server = conn.LocalAddr().String()
-			go h.sendLoop(context.Background(), conn, remoteAddr, session,
+			go h.sendLoop(context.Background(), conn, remoteAddr, m.ID, session,
 				sendDuration)
 		}
 	}


### PR DESCRIPTION
This PR replaces the UUID with the session ID in UDP pings sent in `sendLoop()` and fixes a bug causing pong packets not to be recognized and associated with the correct in-memory session.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/21)
<!-- Reviewable:end -->
