### PR TITLE
Set version via ldflags at compile time

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ VERSION=$(git describe --tags)
 versionflags="-X github.com/m-lab/msak/pkg/version.Version=$VERSION"
 
 COMMIT=$(git log -1 --format=%h)
-versionflags="-X github.com/m-lab/go/prometheusx.GitShortCommit=${COMMIT}"
+versionflags="${versionflags} -X github.com/m-lab/go/prometheusx.GitShortCommit=${COMMIT}"
 
 go build -v \
     -tags netgo \

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+# Script to build msak with the correct flags.
+set -ex
+
+VERSION=$(git describe --tags)
+versionflags="-X github.com/m-lab/msak/pkg/version.Version=$VERSION"
+
 COMMIT=$(git log -1 --format=%h)
 versionflags="-X github.com/m-lab/go/prometheusx.GitShortCommit=${COMMIT}"
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/m-lab/msak/internal/persistence"
 	"github.com/m-lab/msak/pkg/throughput1"
 	"github.com/m-lab/msak/pkg/throughput1/model"
+	"github.com/m-lab/msak/pkg/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -183,7 +184,7 @@ func (h *Handler) upgradeAndRunMeasurement(kind model.TestDirection, rw http.Res
 		Client:         wsConn.UnderlyingConn().RemoteAddr().String(),
 		Direction:      string(kind),
 		GitShortCommit: prometheusx.GitShortCommit,
-		Version:        "v0.0.1",
+		Version:        version.Version,
 		ClientMetadata: metadata,
 		ClientOptions:  clientOptions,
 	}

--- a/pkg/latency1/model/result.go
+++ b/pkg/latency1/model/result.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/m-lab/go/prometheusx"
+	"github.com/m-lab/msak/pkg/version"
 )
 
 // LatencyPacket is the payload of a latency measurement UDP packet.
@@ -151,7 +152,7 @@ func (s *Session) Archive() *ArchivalData {
 	return &ArchivalData{
 		ID:              s.UUID,
 		GitShortCommit:  prometheusx.GitShortCommit,
-		Version:         "TODO",
+		Version:         version.Version,
 		Client:          s.Client,
 		Server:          s.Server,
 		StartTime:       s.StartTime,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+// Version is the version of msak. This is meant to be overridden at compile
+// time using `-ldflags "-X var=value`
+var Version string

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the version of msak. This is meant to be overridden at compile
 // time using `-ldflags "-X var=value`
-var Version string
+var Version = "unspecified"


### PR DESCRIPTION
This PR adds a `version` package with a `Version` variable that is meant to be overwritten at compile time. The build script is also updated to set `version.Version` to the correct value, i.e. the current tag (or tag + short commit hash in case we're not at a tag).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/24)
<!-- Reviewable:end -->
