### PR TITLE
Add latency1 schema to generate-schema tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ WORKDIR /msak
 COPY --from=build /msak/msak-server /msak/
 COPY --from=build /msak/generate-schema /msak/
 
-# Generate msak's JSON schema.
-RUN /msak/generate-schema -throughput1=/msak/throughput1.json
+# Generate msak's JSON schemas.
+RUN /msak/generate-schema -throughput1=/msak/throughput1.json -latency1=/msak/latency1.json
 
 # Verify that the msak-server binary can be run.
 RUN ./msak-server -h

--- a/cmd/generate-schema/main.go
+++ b/cmd/generate-schema/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
+	"os"
 
 	"github.com/m-lab/go/cloud/bqx"
 	"github.com/m-lab/go/rtx"
+	latency1model "github.com/m-lab/msak/pkg/latency1/model"
 	"github.com/m-lab/msak/pkg/throughput1/model"
 
 	"cloud.google.com/go/bigquery"
@@ -13,20 +14,33 @@ import (
 
 var (
 	throughput1Schema string
+	latency1Schema    string
 )
 
 func init() {
 	flag.StringVar(&throughput1Schema, "throughput1", "/var/spool/datatypes/throughput1.json", "filename to write throughput1 schema")
+	flag.StringVar(&latency1Schema, "latency1", "/var/spool/datatypes/latency1.json", "filename to write latency1 schema")
 }
 
 func main() {
 	flag.Parse()
-	// Generate and save ndt7 schema for autoloading.
+	// Generate and save schemas for autoloading.
+	// throughput1 schema.
 	throughput1Result := model.Throughput1Result{}
 	sch, err := bigquery.InferSchema(throughput1Result)
 	rtx.Must(err, "failed to generate throughput1 schema")
 	sch = bqx.RemoveRequired(sch)
 	b, err := sch.ToJSONFields()
-	rtx.Must(err, "failed to marshal schema")
-	ioutil.WriteFile(throughput1Schema, b, 0o644)
+	rtx.Must(err, "failed to marshal throughput1 schema")
+	err = os.WriteFile(throughput1Schema, b, 0o644)
+	rtx.Must(err, "failed to write throughput1 schema")
+	// latency1 schema.
+	latency1Result := latency1model.ArchivalData{}
+	sch, err = bigquery.InferSchema(latency1Result)
+	rtx.Must(err, "failed to generate latency1 schema")
+	sch = bqx.RemoveRequired(sch)
+	b, err = sch.ToJSONFields()
+	rtx.Must(err, "failed to marshal latency1 schema")
+	err = os.WriteFile(latency1Schema, b, 0o644)
+	rtx.Must(err, "failed to write latency1 schema")
 }


### PR DESCRIPTION
Adds `latency1` schema to the generate-schema tool and generate `latency1` schema during Docker build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/25)
<!-- Reviewable:end -->
