### PR TITLE
Replace *net.TCPConn with a TCPLikeConn abstraction

### DIFF
--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -42,7 +42,7 @@ func setupTestWSDialer(u *url.URL) *websocket.Dialer {
 			if err != nil {
 				return nil, err
 			}
-			return netx.FromTCPConn(conn.(*net.TCPConn))
+			return netx.FromTCPLikeConn(conn.(*net.TCPConn))
 		},
 	}
 }

--- a/internal/netx/conn.go
+++ b/internal/netx/conn.go
@@ -33,6 +33,13 @@ type ConnInfo interface {
 	SaveUUID(context.Context) context.Context
 }
 
+// TCPLikeConn is a net.Conn with a File() method. This is useful for creating a
+// netx.Conn based on a custom TCPConn-like type - e.g. for testing.
+type TCPLikeConn interface {
+	net.Conn
+	File() (*os.File, error)
+}
+
 // ToConnInfo is a helper function to convert a net.Conn into a netx.ConnInfo.
 // It panics if netConn does not contain a type supporting ConnInfo.
 func ToConnInfo(netConn net.Conn) ConnInfo {
@@ -57,8 +64,9 @@ type Conn struct {
 	bytesWritten atomic.Uint64
 }
 
-func FromTCPConn(tcpConn *net.TCPConn) (*Conn, error) {
-	return fromTCPConn(tcpConn)
+// FromTCPLikeConn creates a netx.Conn from a TCPLikeConn.
+func FromTCPLikeConn(tcpConn TCPLikeConn) (*Conn, error) {
+	return fromTCPLikeConn(tcpConn)
 }
 
 // Read reads from the underlying net.Conn and updates the read bytes counter.

--- a/internal/netx/conn_linux.go
+++ b/internal/netx/conn_linux.go
@@ -1,11 +1,10 @@
 package netx
 
 import (
-	"net"
 	"time"
 )
 
-func fromTCPConn(tcpConn *net.TCPConn) (*Conn, error) {
+func fromTCPLikeConn(tcpConn TCPLikeConn) (*Conn, error) {
 	// On Linux system, this can only fail when the file duplication fails.
 	fp, err := tcpConn.File()
 	if err != nil {

--- a/internal/netx/conn_stub.go
+++ b/internal/netx/conn_stub.go
@@ -4,11 +4,10 @@
 package netx
 
 import (
-	"net"
 	"time"
 )
 
-func fromTCPConn(tcpConn *net.TCPConn) (*Conn, error) {
+func fromTCPLikeConn(tcpConn TCPLikeConn) (*Conn, error) {
 	// On non-Linux systems, TCPInfo/BBRInfo aren't supported, the file pointer
 	// is not needed.
 	return &Conn{

--- a/internal/netx/listener_stub.go
+++ b/internal/netx/listener_stub.go
@@ -11,5 +11,5 @@ func (ln *Listener) accept() (net.Conn, error) {
 		return nil, err
 	}
 
-	return fromTCPConn(tc)
+	return fromTCPLikeConn(tc)
 }

--- a/pkg/throughput1/protocol_test.go
+++ b/pkg/throughput1/protocol_test.go
@@ -106,7 +106,7 @@ func TestProtocol_Download(t *testing.T) {
 			if err != nil {
 				return nil, err
 			}
-			return netx.FromTCPConn(conn.(*net.TCPConn))
+			return netx.FromTCPLikeConn(conn.(*net.TCPConn))
 		},
 	}
 


### PR DESCRIPTION
This replaces the concrete parameter `*net.TCPConn` of `netx.FromTCPConn` with an equivalent interface. This

- Makes testing easier since we don't need to provide a real `*net.TCPConn`
- Allows `netx.Conn` to wrap other custom `net.Conn`  implementation.
 
e.g. (quick example not guaranteed to compile :) ):

```golang
// MeteredConn updates a shared atomic counter on reads/writes.
type MeteredConn struct {
  *net.TCPConn

  bytesRead    *atomic.Uint64
  bytesWritten *atomic.Uint64
}

func (mc MeteredConn) Write(b []byte) (int, error) {
  n, err := mc.TCPConn.Write(b)
  mc.bytesWritten.Add(uint64(n))
  return n, err
}

func (mc MeteredConn) Read(b []byte) (int, error) {
  n, err := mc.TCPConn.Read(b)
  mc.bytesRead.Add(uint64(n))
  return n, err
}

// Wrap with netx.Conn.
netxConn := netx.FromTCPLikeConn(&MeteredConn{
  TCPConn: actualConn,
  bytesRead: br,
  bytesWritten: bw,
})
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/27)
<!-- Reviewable:end -->
