### PR TITLE
Add support for bytes limit

### DIFF
--- a/cmd/msak-client/client.go
+++ b/cmd/msak-client/client.go
@@ -15,16 +15,16 @@ const clientName = "msak-client-go"
 var clientVersion = version.Version
 
 var (
-	flagServer    = flag.String("server", "", "Server address")
-	flagStreams   = flag.Int("streams", client.DefaultStreams, "Number of streams")
-	flagCC        = flag.String("cc", "bbr", "Congestion control algorithm to use")
-	flagDelay     = flag.Duration("delay", 0, "Delay between each stream")
-	flagDuration  = flag.Duration("duration", client.DefaultLength, "Length of the last stream")
-	flagScheme    = flag.String("scheme", client.DefaultScheme, "Websocket scheme (wss or ws)")
-	flagMID       = flag.String("mid", uuid.NewString(), "Measurement ID to use")
-	flagNoVerify  = flag.Bool("no-verify", false, "Skip TLS certificate verification")
-	flagDebug     = flag.Bool("debug", false, "Enable debug logging")
-	flagByteLimit = flag.Int("bytes", 0, "Byte limit to request to the server")
+	flagServer     = flag.String("server", "", "Server address")
+	flagStreams    = flag.Int("streams", client.DefaultStreams, "Number of streams")
+	flagCC         = flag.String("cc", "bbr", "Congestion control algorithm to use")
+	flagDelay      = flag.Duration("delay", 0, "Delay between each stream")
+	flagDuration   = flag.Duration("duration", client.DefaultLength, "Length of the last stream")
+	flagScheme     = flag.String("scheme", client.DefaultScheme, "Websocket scheme (wss or ws)")
+	flagMID        = flag.String("mid", uuid.NewString(), "Measurement ID to use")
+	flagNoVerify   = flag.Bool("no-verify", false, "Skip TLS certificate verification")
+	flagDebug      = flag.Bool("debug", false, "Enable debug logging")
+	flagBytesLimit = flag.Int("bytes", 0, "Byte limit to request to the server")
 )
 
 func main() {
@@ -47,8 +47,8 @@ func main() {
 		Emitter: client.HumanReadable{
 			Debug: *flagDebug,
 		},
-		NoVerify:  *flagNoVerify,
-		ByteLimit: *flagByteLimit,
+		NoVerify:   *flagNoVerify,
+		BytesLimit: *flagBytesLimit,
 	}
 
 	cl := client.New(clientName, clientVersion, config)

--- a/cmd/msak-client/client.go
+++ b/cmd/msak-client/client.go
@@ -24,7 +24,7 @@ var (
 	flagMID        = flag.String("mid", uuid.NewString(), "Measurement ID to use")
 	flagNoVerify   = flag.Bool("no-verify", false, "Skip TLS certificate verification")
 	flagDebug      = flag.Bool("debug", false, "Enable debug logging")
-	flagBytesLimit = flag.Int("bytes", 0, "Byte limit to request to the server")
+	flagByteLimit = flag.Int("bytes", 0, "Byte limit to request to the server")
 )
 
 func main() {
@@ -48,7 +48,7 @@ func main() {
 			Debug: *flagDebug,
 		},
 		NoVerify:   *flagNoVerify,
-		BytesLimit: *flagBytesLimit,
+		ByteLimit: *flagByteLimit,
 	}
 
 	cl := client.New(clientName, clientVersion, config)

--- a/cmd/msak-client/client.go
+++ b/cmd/msak-client/client.go
@@ -15,15 +15,16 @@ const clientName = "msak-client-go"
 var clientVersion = version.Version
 
 var (
-	flagServer   = flag.String("server", "", "Server address")
-	flagStreams  = flag.Int("streams", client.DefaultStreams, "Number of streams")
-	flagCC       = flag.String("cc", "bbr", "Congestion control algorithm to use")
-	flagDelay    = flag.Duration("delay", 0, "Delay between each stream")
-	flagDuration = flag.Duration("duration", client.DefaultLength, "Length of the last stream")
-	flagScheme   = flag.String("scheme", client.DefaultScheme, "Websocket scheme (wss or ws)")
-	flagMID      = flag.String("mid", uuid.NewString(), "Measurement ID to use")
-	flagNoVerify = flag.Bool("no-verify", false, "Skip TLS certificate verification")
-	flagDebug    = flag.Bool("debug", false, "Enable debug logging")
+	flagServer    = flag.String("server", "", "Server address")
+	flagStreams   = flag.Int("streams", client.DefaultStreams, "Number of streams")
+	flagCC        = flag.String("cc", "bbr", "Congestion control algorithm to use")
+	flagDelay     = flag.Duration("delay", 0, "Delay between each stream")
+	flagDuration  = flag.Duration("duration", client.DefaultLength, "Length of the last stream")
+	flagScheme    = flag.String("scheme", client.DefaultScheme, "Websocket scheme (wss or ws)")
+	flagMID       = flag.String("mid", uuid.NewString(), "Measurement ID to use")
+	flagNoVerify  = flag.Bool("no-verify", false, "Skip TLS certificate verification")
+	flagDebug     = flag.Bool("debug", false, "Enable debug logging")
+	flagByteLimit = flag.Int("bytes", 0, "Byte limit to request to the server")
 )
 
 func main() {
@@ -46,7 +47,8 @@ func main() {
 		Emitter: client.HumanReadable{
 			Debug: *flagDebug,
 		},
-		NoVerify: *flagNoVerify,
+		NoVerify:  *flagNoVerify,
+		ByteLimit: *flagByteLimit,
 	}
 
 	cl := client.New(clientName, clientVersion, config)

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -131,19 +131,19 @@ func (h *Handler) upgradeAndRunMeasurement(kind model.TestDirection, rw http.Res
 			model.NameValue{Name: "delay", Value: requestDelay})
 	}
 
-	requestByteLimit := query.Get(spec.ByteLimitParameterName)
-	var byteLimit int
-	if requestByteLimit != "" {
-		// Check that byteLimit is a valid integer.
-		if v, err := strconv.Atoi(requestByteLimit); err == nil {
-			byteLimit = v
+	requestBytesLimit := query.Get(spec.BytesLimitParameterName)
+	var bytesLimit int
+	if requestBytesLimit != "" {
+		// Check that bytesLimit is a valid integer.
+		if v, err := strconv.Atoi(requestBytesLimit); err == nil {
+			bytesLimit = v
 			clientOptions = append(clientOptions,
-				model.NameValue{Name: spec.ByteLimitParameterName, Value: requestByteLimit})
+				model.NameValue{Name: spec.BytesLimitParameterName, Value: requestBytesLimit})
 		} else {
 			ClientConnections.WithLabelValues(string(kind),
 				"invalid-byte-limit").Inc()
 			log.Info("Received request with an invalid byte limit",
-				"source", req.RemoteAddr, "value", byteLimit)
+				"source", req.RemoteAddr, "value", bytesLimit)
 			writeBadRequest(rw)
 			return
 		}
@@ -217,7 +217,7 @@ func (h *Handler) upgradeAndRunMeasurement(kind model.TestDirection, rw http.Res
 	defer cancel()
 
 	proto := throughput1.New(wsConn)
-	proto.SetByteLimit(byteLimit)
+	proto.SetBytesLimit(bytesLimit)
 	var senderCh, receiverCh <-chan model.WireMeasurement
 	var errCh <-chan error
 	if kind == model.DirectionDownload {

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -216,6 +216,11 @@ func TestHandler_Validation(t *testing.T) {
 			statusCode: http.StatusBadRequest,
 		},
 		{
+			name:       "invalid byte limit",
+			target:     "/?mid=test&streams=2&duration=1000&bytes=invalid",
+			statusCode: http.StatusBadRequest,
+		},
+		{
 			name:       "metadata key too long",
 			target:     "/?mid=test&streams=2&" + longKey,
 			statusCode: http.StatusBadRequest,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -136,6 +136,7 @@ func (c *Throughput1Client) connect(ctx context.Context, serviceURL *url.URL) (*
 	q := serviceURL.Query()
 	q.Set("streams", fmt.Sprint(c.config.NumStreams))
 	q.Set("cc", c.config.CongestionControl)
+	q.Set(spec.ByteLimitParameterName, fmt.Sprint(c.config.ByteLimit))
 	q.Set("duration", fmt.Sprintf("%d", c.config.Length.Milliseconds()))
 	q.Set("client_arch", runtime.GOARCH)
 	q.Set("client_library_name", libraryName)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -136,7 +136,7 @@ func (c *Throughput1Client) connect(ctx context.Context, serviceURL *url.URL) (*
 	q := serviceURL.Query()
 	q.Set("streams", fmt.Sprint(c.config.NumStreams))
 	q.Set("cc", c.config.CongestionControl)
-	q.Set(spec.ByteLimitParameterName, fmt.Sprint(c.config.ByteLimit))
+	q.Set(spec.BytesLimitParameterName, fmt.Sprint(c.config.BytesLimit))
 	q.Set("duration", fmt.Sprintf("%d", c.config.Length.Milliseconds()))
 	q.Set("client_arch", runtime.GOARCH)
 	q.Set("client_library_name", libraryName)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -136,7 +136,7 @@ func (c *Throughput1Client) connect(ctx context.Context, serviceURL *url.URL) (*
 	q := serviceURL.Query()
 	q.Set("streams", fmt.Sprint(c.config.NumStreams))
 	q.Set("cc", c.config.CongestionControl)
-	q.Set(spec.BytesLimitParameterName, fmt.Sprint(c.config.BytesLimit))
+	q.Set(spec.ByteLimitParameterName, fmt.Sprint(c.config.ByteLimit))
 	q.Set("duration", fmt.Sprintf("%d", c.config.Length.Milliseconds()))
 	q.Set("client_arch", runtime.GOARCH)
 	q.Set("client_library_name", libraryName)

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	// NoVerify disables the TLS certificate verification.
 	NoVerify bool
 
-	// ByteLimit is the maximum number of bytes to download or upload. If set to 0, the
+	// BytesLimit is the maximum number of bytes to download or upload. If set to 0, the
 	// limit is disabled.
-	ByteLimit int
+	BytesLimit int
 }

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	// NoVerify disables the TLS certificate verification.
 	NoVerify bool
 
-	// BytesLimit is the maximum number of bytes to download or upload. If set to 0, the
+	// ByteLimit is the maximum number of bytes to download or upload. If set to 0, the
 	// limit is disabled.
-	BytesLimit int
+	ByteLimit int
 }

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -35,4 +35,8 @@ type Config struct {
 
 	// NoVerify disables the TLS certificate verification.
 	NoVerify bool
+
+	// ByteLimit is the maximum number of bytes to download or upload. If set to 0, the
+	// limit is disabled.
+	ByteLimit int
 }

--- a/pkg/throughput1/protocol.go
+++ b/pkg/throughput1/protocol.go
@@ -48,7 +48,7 @@ type Protocol struct {
 	applicationBytesReceived atomic.Int64
 	applicationBytesSent     atomic.Int64
 
-	bytesLimit int
+	byteLimit int64
 }
 
 // New returns a new Protocol with the specified connection and every other
@@ -63,10 +63,10 @@ func New(conn *websocket.Conn) *Protocol {
 	}
 }
 
-// SetBytesLimit sets the number of bytes sent after which a test (either download or upload) will stop.
+// SetByteLimit sets the number of bytes sent after which a test (either download or upload) will stop.
 // Set the value to zero to disable the byte limit.
-func (p *Protocol) SetBytesLimit(value int) {
-	p.bytesLimit = value
+func (p *Protocol) SetByteLimit(value int) {
+	p.byteLimit = int64(value)
 }
 
 // Upgrade takes a HTTP request and upgrades the connection to WebSocket.
@@ -228,7 +228,7 @@ func (p *Protocol) sendCounterflow(ctx context.Context,
 			}
 
 			// End the test once enough bytes have been received.
-			if p.bytesLimit > 0 && m.TCPInfo != nil && m.TCPInfo.BytesReceived >= int64(p.bytesLimit) {
+			if p.byteLimit > 0 && m.TCPInfo != nil && m.TCPInfo.BytesReceived >= p.byteLimit {
 				p.close(ctx)
 				return
 			}
@@ -290,7 +290,7 @@ func (p *Protocol) sender(ctx context.Context, measurerCh <-chan model.Measureme
 			}
 
 			// End the test once enough bytes have been acked.
-			if p.bytesLimit > 0 && m.TCPInfo != nil && m.TCPInfo.BytesAcked >= int64(p.bytesLimit) {
+			if p.byteLimit > 0 && m.TCPInfo != nil && m.TCPInfo.BytesAcked >= p.byteLimit {
 				p.close(ctx)
 				return
 			}

--- a/pkg/throughput1/protocol.go
+++ b/pkg/throughput1/protocol.go
@@ -48,7 +48,7 @@ type Protocol struct {
 	applicationBytesReceived atomic.Int64
 	applicationBytesSent     atomic.Int64
 
-	byteLimit int
+	bytesLimit int
 }
 
 // New returns a new Protocol with the specified connection and every other
@@ -63,10 +63,10 @@ func New(conn *websocket.Conn) *Protocol {
 	}
 }
 
-// SetByteLimit sets the number of bytes sent after which a test (either download or upload) will stop.
+// SetBytesLimit sets the number of bytes sent after which a test (either download or upload) will stop.
 // Set the value to zero to disable the byte limit.
-func (p *Protocol) SetByteLimit(value int) {
-	p.byteLimit = value
+func (p *Protocol) SetBytesLimit(value int) {
+	p.bytesLimit = value
 }
 
 // Upgrade takes a HTTP request and upgrades the connection to WebSocket.
@@ -228,7 +228,7 @@ func (p *Protocol) sendCounterflow(ctx context.Context,
 			}
 
 			// End the test once enough bytes have been received.
-			if p.byteLimit > 0 && m.TCPInfo != nil && m.TCPInfo.BytesReceived >= int64(p.byteLimit) {
+			if p.bytesLimit > 0 && m.TCPInfo != nil && m.TCPInfo.BytesReceived >= int64(p.bytesLimit) {
 				p.close(ctx)
 				return
 			}
@@ -290,7 +290,7 @@ func (p *Protocol) sender(ctx context.Context, measurerCh <-chan model.Measureme
 			}
 
 			// End the test once enough bytes have been acked.
-			if p.byteLimit > 0 && m.TCPInfo != nil && m.TCPInfo.BytesAcked >= int64(p.byteLimit) {
+			if p.bytesLimit > 0 && m.TCPInfo != nil && m.TCPInfo.BytesAcked >= int64(p.bytesLimit) {
 				p.close(ctx)
 				return
 			}

--- a/pkg/throughput1/protocol.go
+++ b/pkg/throughput1/protocol.go
@@ -48,7 +48,7 @@ type Protocol struct {
 	applicationBytesReceived atomic.Int64
 	applicationBytesSent     atomic.Int64
 
-	byteLimit int64
+	byteLimit int
 }
 
 // New returns a new Protocol with the specified connection and every other
@@ -66,7 +66,7 @@ func New(conn *websocket.Conn) *Protocol {
 // SetByteLimit sets the number of bytes sent after which a test (either download or upload) will stop.
 // Set the value to zero to disable the byte limit.
 func (p *Protocol) SetByteLimit(value int) {
-	p.byteLimit = int64(value)
+	p.byteLimit = value
 }
 
 // Upgrade takes a HTTP request and upgrades the connection to WebSocket.
@@ -188,6 +188,7 @@ func (p *Protocol) receiver(ctx context.Context,
 func (p *Protocol) sendCounterflow(ctx context.Context,
 	measurerCh <-chan model.Measurement, results chan<- model.WireMeasurement,
 	errCh chan<- error) {
+	byteLimit := int64(p.byteLimit)
 	for {
 		select {
 		case <-ctx.Done():
@@ -228,7 +229,7 @@ func (p *Protocol) sendCounterflow(ctx context.Context,
 			}
 
 			// End the test once enough bytes have been received.
-			if p.byteLimit > 0 && m.TCPInfo != nil && m.TCPInfo.BytesReceived >= p.byteLimit {
+			if byteLimit > 0 && m.TCPInfo != nil && m.TCPInfo.BytesReceived >= byteLimit {
 				p.close(ctx)
 				return
 			}
@@ -238,7 +239,7 @@ func (p *Protocol) sendCounterflow(ctx context.Context,
 
 func (p *Protocol) sender(ctx context.Context, measurerCh <-chan model.Measurement,
 	results chan<- model.WireMeasurement, errCh chan<- error) {
-	size := spec.MinMessageSize
+	size := p.ScaleMessage(spec.MinMessageSize, 0)
 	message, err := p.makePreparedMessage(size)
 	if err != nil {
 		log.Printf("makePreparedMessage failed (ctx: %p)", ctx)
@@ -288,12 +289,6 @@ func (p *Protocol) sender(ctx context.Context, measurerCh <-chan model.Measureme
 			case results <- wm:
 			default:
 			}
-
-			// End the test once enough bytes have been acked.
-			if p.byteLimit > 0 && m.TCPInfo != nil && m.TCPInfo.BytesAcked >= p.byteLimit {
-				p.close(ctx)
-				return
-			}
 		default:
 			err = p.conn.WritePreparedMessage(message)
 			if err != nil {
@@ -303,25 +298,37 @@ func (p *Protocol) sender(ctx context.Context, measurerCh <-chan model.Measureme
 			}
 			p.applicationBytesSent.Add(int64(size))
 
+			bytesSent := int(p.applicationBytesSent.Load())
+			if p.byteLimit > 0 && bytesSent >= p.byteLimit {
+				p.close(ctx)
+				return
+			}
+
 			// Determine whether it's time to scale the message size.
-			if size >= spec.MaxScaledMessageSize {
+			if size >= spec.MaxScaledMessageSize || size > bytesSent/spec.ScalingFraction {
+				size = p.ScaleMessage(size, bytesSent)
 				continue
 			}
 
-			if size > int(p.applicationBytesSent.Load())/spec.ScalingFraction {
-				continue
-			}
-
-			size *= 2
+			size = p.ScaleMessage(size*2, bytesSent)
 			message, err = p.makePreparedMessage(size)
 			if err != nil {
 				log.Printf("failed to make prepared message (ctx: %p, err: %v)", ctx, err)
 				errCh <- err
 				return
 			}
-
 		}
 	}
+}
+
+// ScaleMessage sets the binary message size taking into consideration byte limits.
+func (p *Protocol) ScaleMessage(msgSize int, bytesSent int) int {
+	// Check if the next payload size will push the total number of bytes over the limit.
+	excess := bytesSent + msgSize - p.byteLimit
+	if p.byteLimit > 0 && excess > 0 {
+		msgSize -= excess
+	}
+	return msgSize
 }
 
 func (p *Protocol) close(ctx context.Context) {

--- a/pkg/throughput1/protocol_test.go
+++ b/pkg/throughput1/protocol_test.go
@@ -137,3 +137,51 @@ func TestProtocol_Download(t *testing.T) {
 		}
 	}
 }
+
+func TestProtocol_ScaleMessage(t *testing.T) {
+	tests := []struct {
+		name      string
+		byteLimit int
+		msgSize   int
+		bytesSent int
+		want      int
+	}{
+		{
+			name:      "no-limit",
+			byteLimit: 0,
+			msgSize:   10,
+			bytesSent: 100,
+			want:      10,
+		},
+		{
+			name:      "under-limit",
+			byteLimit: 200,
+			msgSize:   10,
+			bytesSent: 100,
+			want:      10,
+		},
+		{
+			name:      "at-limit",
+			byteLimit: 110,
+			msgSize:   10,
+			bytesSent: 100,
+			want:      10,
+		},
+		{
+			name:      "over-limit",
+			byteLimit: 110,
+			msgSize:   20,
+			bytesSent: 100,
+			want:      10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &throughput1.Protocol{}
+			p.SetByteLimit(tt.byteLimit)
+			if got := p.ScaleMessage(tt.msgSize, tt.bytesSent); got != tt.want {
+				t.Errorf("Protocol.ScaleMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/throughput1/spec/spec.go
+++ b/pkg/throughput1/spec/spec.go
@@ -37,6 +37,11 @@ const (
 
 	// SecWebSocketProtocol is the value of the Sec-WebSocket-Protocol header.
 	SecWebSocketProtocol = "net.measurementlab.throughput.v1"
+
+	// ByteLimitParameterName is the name of the parameter that clients can use
+	// to terminate throughput1 download tests once the test has transferred
+	// the specified number of bytes.
+	ByteLimitParameterName = "bytes"
 )
 
 // SubtestKind indicates the subtest kind

--- a/pkg/throughput1/spec/spec.go
+++ b/pkg/throughput1/spec/spec.go
@@ -38,10 +38,10 @@ const (
 	// SecWebSocketProtocol is the value of the Sec-WebSocket-Protocol header.
 	SecWebSocketProtocol = "net.measurementlab.throughput.v1"
 
-	// ByteLimitParameterName is the name of the parameter that clients can use
+	// BytesLimitParameterName is the name of the parameter that clients can use
 	// to terminate throughput1 download tests once the test has transferred
 	// the specified number of bytes.
-	ByteLimitParameterName = "bytes"
+	BytesLimitParameterName = "bytes"
 )
 
 // SubtestKind indicates the subtest kind

--- a/pkg/throughput1/spec/spec.go
+++ b/pkg/throughput1/spec/spec.go
@@ -38,10 +38,10 @@ const (
 	// SecWebSocketProtocol is the value of the Sec-WebSocket-Protocol header.
 	SecWebSocketProtocol = "net.measurementlab.throughput.v1"
 
-	// BytesLimitParameterName is the name of the parameter that clients can use
+	// ByteLimitParameterName is the name of the parameter that clients can use
 	// to terminate throughput1 download tests once the test has transferred
 	// the specified number of bytes.
-	BytesLimitParameterName = "bytes"
+	ByteLimitParameterName = "bytes"
 )
 
 // SubtestKind indicates the subtest kind


### PR DESCRIPTION
The `bytes` querystring parameter allows the client to specify the maximum number of bytes the server will send/receive before terminating the connection.

The limit is only enabled on the server, since the server is almost always guaranteed to have access to the connection's `TCPInfo`.

The check is implemented in `Protocol.sendCounterflow()` for upload tests (where it checks `TCPInfo.BytesReceived`) and in `Protocol.sender()` for download tests (where it checks `TCPInfo.BytesAcked`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/29)
<!-- Reviewable:end -->
