### PR TITLE
fix(archive): archive final messages sent to client

### DIFF
--- a/pkg/throughput1/protocol.go
+++ b/pkg/throughput1/protocol.go
@@ -212,11 +212,11 @@ func (p *Protocol) sendCounterflow(ctx context.Context,
 		select {
 		case <-ctx.Done():
 			// Attempt to send final write message before close. Ignore errors.
-			p.sendAndSaveWireMessage(ctx, p.measurer.Measure(ctx), results)
+			p.sendAndPublishWireMeasurement(ctx, p.measurer.Measure(ctx), results)
 			p.close(ctx)
 			return
 		case m := <-measurerCh:
-			err := p.sendAndSaveWireMessage(ctx, m, results)
+			err := p.sendAndPublishWireMeasurement(ctx, m, results)
 			if err != nil {
 				errCh <- err
 				return
@@ -232,7 +232,7 @@ func (p *Protocol) sendCounterflow(ctx context.Context,
 	}
 }
 
-func (p *Protocol) sendAndSaveWireMessage(ctx context.Context, m model.Measurement, results chan<- model.WireMeasurement) error {
+func (p *Protocol) sendAndPublishWireMeasurement(ctx context.Context, m model.Measurement, results chan<- model.WireMeasurement) error {
 	wm, err := p.sendWireMeasurement(ctx, m)
 	if err != nil {
 		return err
@@ -265,11 +265,11 @@ func (p *Protocol) sender(ctx context.Context, measurerCh <-chan model.Measureme
 		select {
 		case <-ctx.Done():
 			// Attempt to send final write message before close. Ignore errors.
-			p.sendAndSaveWireMessage(ctx, p.measurer.Measure(ctx), results)
+			p.sendAndPublishWireMeasurement(ctx, p.measurer.Measure(ctx), results)
 			p.close(ctx)
 			return
 		case m := <-measurerCh:
-			err := p.sendAndSaveWireMessage(ctx, m, results)
+			err := p.sendAndPublishWireMeasurement(ctx, m, results)
 			if err != nil {
 				errCh <- err
 				return
@@ -285,7 +285,7 @@ func (p *Protocol) sender(ctx context.Context, measurerCh <-chan model.Measureme
 
 			bytesSent := int(p.applicationBytesSent.Load())
 			if p.byteLimit > 0 && bytesSent >= p.byteLimit {
-				err := p.sendAndSaveWireMessage(ctx, p.measurer.Measure(ctx), results)
+				err := p.sendAndPublishWireMeasurement(ctx, p.measurer.Measure(ctx), results)
 				if err != nil {
 					errCh <- err
 					return

--- a/pkg/throughput1/protocol.go
+++ b/pkg/throughput1/protocol.go
@@ -212,20 +212,14 @@ func (p *Protocol) sendCounterflow(ctx context.Context,
 		select {
 		case <-ctx.Done():
 			// Attempt to send final write message before close. Ignore errors.
-			p.sendWireMeasurement(ctx, p.measurer.Measure(ctx))
+			p.sendAndSaveWireMessage(ctx, p.measurer.Measure(ctx), results)
 			p.close(ctx)
 			return
 		case m := <-measurerCh:
-			wm, err := p.sendWireMeasurement(ctx, m)
+			err := p.sendAndSaveWireMessage(ctx, m, results)
 			if err != nil {
 				errCh <- err
 				return
-			}
-			// This send is non-blocking in case there is no one to read the
-			// Measurement message and the channel's buffer is full.
-			select {
-			case results <- *wm:
-			default:
 			}
 
 			// End the test once enough bytes have been received.
@@ -236,6 +230,21 @@ func (p *Protocol) sendCounterflow(ctx context.Context,
 			}
 		}
 	}
+}
+
+func (p *Protocol) sendAndSaveWireMessage(ctx context.Context, m model.Measurement, results chan<- model.WireMeasurement) error {
+	wm, err := p.sendWireMeasurement(ctx, m)
+	if err != nil {
+		return err
+	}
+
+	// This send is non-blocking in case there is no one to read the
+	// Measurement message and the channel's buffer is full.
+	select {
+	case results <- *wm:
+	default:
+	}
+	return nil
 }
 
 func (p *Protocol) sender(ctx context.Context, measurerCh <-chan model.Measurement,
@@ -256,21 +265,14 @@ func (p *Protocol) sender(ctx context.Context, measurerCh <-chan model.Measureme
 		select {
 		case <-ctx.Done():
 			// Attempt to send final write message before close. Ignore errors.
-			p.sendWireMeasurement(ctx, p.measurer.Measure(ctx))
+			p.sendAndSaveWireMessage(ctx, p.measurer.Measure(ctx), results)
 			p.close(ctx)
 			return
 		case m := <-measurerCh:
-			wm, err := p.sendWireMeasurement(ctx, m)
+			err := p.sendAndSaveWireMessage(ctx, m, results)
 			if err != nil {
 				errCh <- err
 				return
-			}
-
-			// This send is non-blocking in case there is no one to read the
-			// Measurement message and the channel's buffer is full.
-			select {
-			case results <- *wm:
-			default:
 			}
 		default:
 			err = p.conn.WritePreparedMessage(message)
@@ -283,7 +285,7 @@ func (p *Protocol) sender(ctx context.Context, measurerCh <-chan model.Measureme
 
 			bytesSent := int(p.applicationBytesSent.Load())
 			if p.byteLimit > 0 && bytesSent >= p.byteLimit {
-				_, err := p.sendWireMeasurement(ctx, p.measurer.Measure(ctx))
+				err := p.sendAndSaveWireMessage(ctx, p.measurer.Measure(ctx), results)
 				if err != nil {
 					errCh <- err
 					return


### PR DESCRIPTION
Previously, https://github.com/m-lab/msak/pull/30 ensured that before closing the connection a final measurement message was sent to the client. However, that message was not saved in the archival result.

This change ensures that the final measurement is saved to the archival results.

Fixes: https://github.com/m-lab/msak/issues/32

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/34)
<!-- Reviewable:end -->
