### PR TITLE
Fix goodput calculation in msak-client

### DIFF
--- a/pkg/client/emitter.go
+++ b/pkg/client/emitter.go
@@ -35,7 +35,7 @@ type HumanReadable struct {
 // OnResult prints the aggregate result.
 func (HumanReadable) OnResult(r Result) {
 	fmt.Printf("Elapsed: %.2fs, Goodput: %f Mb/s, MinRTT: %d\n", r.Elapsed.Seconds(),
-		r.Goodput/1024/1024, r.MinRTT)
+		r.Goodput/1e6, r.MinRTT)
 }
 
 // OnStart is called when the stream starts and prints the subtest and server hostname.


### PR DESCRIPTION
- Fix goodput computation (denominator is `1e6` not `1024*1024`)
- Remove fixed-interval emit loop and align output with incoming messages

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/36)
<!-- Reviewable:end -->
