### PR TITLE
Add minimal, multi stream support to minimal-download client

### DIFF
--- a/cmd/minimal-download/main.go
+++ b/cmd/minimal-download/main.go
@@ -301,16 +301,16 @@ outer:
 				}
 				s.minRTT.Store(m.TCPInfo["MinRTT"])
 
-				if streamCount == 1 {
+				switch {
+				case streamCount == 1:
 					// Use server metrics for single stream tests.
 					formatMessage("Download server", 1, m)
-				} else {
-					if stream == 0 {
-						// Only do this for one stream.
-						log.Printf("Download client #1 - Avg %0.2f Mbps, elapsed %0.4fs, application r/w: %d/%d\n",
-							8*float64(s.applicationBytesReceived.Load())/1e6/time.Since(start).Seconds(), // as mbps.
-							time.Since(start).Seconds(), 0, s.applicationBytesReceived.Load())
-					}
+				case streamCount > 1 && stream == 0:
+					// Only do this for one stream.
+					elapsed := time.Since(start)
+					log.Printf("Download client #1 - Avg %0.2f Mbps, elapsed %0.4fs, application r/w: %d/%d\n",
+						8*float64(s.applicationBytesReceived.Load())/1e6/elapsed.Seconds(), // as mbps.
+						elapsed.Seconds(), 0, s.applicationBytesReceived.Load())
 				}
 			}
 		}

--- a/cmd/minimal-download/main.go
+++ b/cmd/minimal-download/main.go
@@ -341,7 +341,7 @@ func main() {
 	}
 	// Get common URL and headers.
 	u, headers := prepareHeaders(ctx, srv)
-	log.Printf("Connecting: %s://%s/%s", srv.Scheme, srv.Host, srv.Path)
+	log.Printf("Connecting: %s://%s/%s?...", srv.Scheme, srv.Host, srv.Path)
 
 	s := &sharedResults{}
 	wg := &sync.WaitGroup{}
@@ -353,15 +353,16 @@ func main() {
 
 	log.Println("------")
 	elapsedAvg := s.firstStopTime.Sub(s.firstStartTime)
-	bytesAvg := s.bytesAtFirstStop.Load() // like msak-client.
+	bytesAvg := s.bytesAtFirstStop.Load() // like msak-client, bytes during first-start to first-stop.
 	log.Printf("Download client #1 - Avg  %0.2f Mbps, MinRTT %5.2fms, elapsed %0.4fs, application r/w: %d/%d\n",
 		8*float64(bytesAvg)/1e6/elapsedAvg.Seconds(), // as mbps.
 		float64(s.minRTT.Load())/1000.0,              // as ms.
 		elapsedAvg.Seconds(), 0, bytesAvg)
 
-	if *flagStreams > 1 {
-		elapsedPeak := s.firstStopTime.Sub(s.lastStartTime)
-		bytesPeak := s.bytesAtFirstStop.Load() - s.bytesAtLastStart.Load() // avg of peak period.
+	// TODO: we assume connections all overlap during peak periods.
+	elapsedPeak := s.firstStopTime.Sub(s.lastStartTime)
+	bytesPeak := s.bytesAtFirstStop.Load() - s.bytesAtLastStart.Load() // bytes during of peak period.
+	if *flagStreams > 1 && bytesPeak > 0 && elapsedPeak > 0 {
 		log.Printf("Download client #1 - Peak %0.2f Mbps, MinRTT %5.2fms, elapsed %0.4fs, application r/w: %d/%d\n",
 			8*float64(bytesPeak)/1e6/elapsedPeak.Seconds(), // as mbps.
 			float64(s.minRTT.Load())/1000.0,                // as ms.

--- a/cmd/minimal-download/main.go
+++ b/cmd/minimal-download/main.go
@@ -311,9 +311,7 @@ outer:
 					formatMessage("Download server", 1, m)
 				case streamCount > 1 && stream == 0:
 					// Only do this for one stream.
-					s.mu.Lock()
 					elapsed := time.Since(s.firstStartTime)
-					s.mu.Unlock()
 					log.Printf("Download client #1 - Avg  %0.2f Mbps, MinRTT %5.2fms, elapsed %0.4fs, application r/w: %d/%d\n",
 						8*float64(s.bytesTotal.Load())/1e6/elapsed.Seconds(), // as mbps.
 						float64(s.minRTT.Load())/1000.0,                      // as ms.

--- a/cmd/minimal-download/main.go
+++ b/cmd/minimal-download/main.go
@@ -336,7 +336,7 @@ func main() {
 	}
 	// Get common URL and headers.
 	u, headers := prepareHeaders(ctx, srv)
-	log.Printf("Connecting: %s://%s/%s?...", srv.Scheme, srv.Host, srv.Path)
+	log.Printf("Connecting: %s://%s%s?...", srv.Scheme, srv.Host, srv.Path)
 
 	s := &sharedResults{}
 	wg := &sync.WaitGroup{}

--- a/cmd/minimal-download/main.go
+++ b/cmd/minimal-download/main.go
@@ -208,10 +208,10 @@ func getDownloadServer(ctx context.Context) (*url.URL, error) {
 }
 
 type sharedResults struct {
-	bytesTotal       atomic.Int64
-	bytesAtLastStart atomic.Int64
-	bytesAtFirstStop atomic.Int64
-	minRTT           atomic.Int64
+	bytesTotal       atomic.Int64 // total bytes seen over the life of all connections.
+	bytesAtLastStart atomic.Int64 // total bytes seen when the last connection starts.
+	bytesAtFirstStop atomic.Int64 // total bytes seen when the first connection stops/closes.
+	minRTT           atomic.Int64 // minimum of all MinRTT values from all connections.
 	mu               sync.Mutex
 	started          atomic.Bool // set true after first connection opens.
 	firstStartTime   time.Time

--- a/cmd/minimal-download/main.go
+++ b/cmd/minimal-download/main.go
@@ -14,7 +14,6 @@ import (
 	"net/url"
 	"path"
 	"runtime"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -32,14 +31,14 @@ const (
 var (
 	flagCC          = flag.String("cc", "bbr", "Congestion control algorithm to use")
 	flagDuration    = flag.Duration("duration", 5*time.Second, "Length of the last stream")
-	flagMaxDuration = flag.Duration("max-duration", 15*time.Second, "Maximum length of any stream")
+	flagMaxDuration = flag.Duration("max-duration", 15*time.Second, "Maximum length of all connections")
 	flagByteLimit   = flag.Int("bytes", 0, "Byte limit to request to the server")
 	flagNoVerify    = flag.Bool("no-verify", false, "Skip TLS certificate verification")
 	flagServerURL   = flag.String("server.url", "", "URL to directly target")
 	flagMID         = flag.String("server.mid", uuid.NewString(), "Measurement ID to use")
 	flagScheme      = flag.String("locate.scheme", "wss", "Websocket scheme (wss or ws)")
 	flagLocateURL   = flag.String("locate.url", locateURL, "The base url for the Locate API")
-	flagStreams     = flag.Int("streams", 1, "The number of streams to create")
+	flagStreams     = flag.Int("streams", 1, "The number of concurrent streams to create")
 )
 
 // WireMeasurement is a wrapper for Measurement structs that contains
@@ -202,10 +201,6 @@ func getDownloadServer(ctx context.Context) (*url.URL, error) {
 	// Just use the first result.
 	for i := range targets {
 		srvurl := targets[i].URLs[*flagScheme+":///throughput/v1/download"]
-		if strings.Contains(srvurl, "lga06") {
-			log.Println("skipping lga06")
-			continue
-		}
 		// Get server url.
 		return url.Parse(srvurl)
 	}


### PR DESCRIPTION
Previously, the `minimal-download` client only operated on a single stream. To contrast this tool with other multi stream tools, this change adds a minimal support for multi stream downloads.

The final download rate is currently calculated from the "first-open to first-close" time window.

For example:

```
$ minimal-download -duration 1s -streams 3
Connecting: wss://msak-mlab3-lga04.mlab-oti.measurement-lab.org/throughput/v1/download?...
Download client #1 - Avg  437.05 Mbps, MinRTT  4.55ms, elapsed 0.4319s, application r/w: 0/23595261
Download client #1 - Avg  484.26 Mbps, MinRTT  4.45ms, elapsed 0.8316s, application r/w: 0/50340258
Download client #1 - Avg  483.72 Mbps, MinRTT  4.45ms, elapsed 0.9366s, application r/w: 0/56634811
Download client #1 - Avg  491.40 Mbps, MinRTT  4.45ms, elapsed 1.0415s, application r/w: 0/63975876
Download client #1 - Avg  486.51 Mbps, MinRTT  4.45ms, elapsed 1.2245s, application r/w: 0/74464752
------
Download client #1 - Avg  490.41 Mbps, MinRTT  4.45ms, elapsed 1.1292s, application r/w: 0/69219792
Download client #1 - Peak 500.53 Mbps, MinRTT  4.45ms, elapsed 1.1057s, application r/w: 0/69178832
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/38)
<!-- Reviewable:end -->
