### PR TITLE
Add summary at the end of the measurement and fix RTT calc

### DIFF
--- a/cmd/msak-client/client.go
+++ b/cmd/msak-client/client.go
@@ -65,4 +65,6 @@ func main() {
 	if *flagUpload {
 		cl.Upload(context.Background())
 	}
+
+	cl.PrintSummary()
 }

--- a/pkg/client/emitter.go
+++ b/pkg/client/emitter.go
@@ -34,8 +34,8 @@ type HumanReadable struct {
 
 // OnResult prints the aggregate result.
 func (HumanReadable) OnResult(r Result) {
-	fmt.Printf("Elapsed: %.2fs, Goodput: %f Mb/s, MinRTT: %d\n", r.Elapsed.Seconds(),
-		r.Goodput/1e6, r.MinRTT)
+	fmt.Printf("Download rate: %f Mb/s, rtt: %.2f, minrtt: %.2f\n",
+		r.Goodput/1e6, float32(r.RTT)/1000, float32(r.MinRTT)/1000)
 }
 
 // OnStart is called when the stream starts and prints the subtest and server hostname.

--- a/pkg/client/emitter.go
+++ b/pkg/client/emitter.go
@@ -36,8 +36,8 @@ type HumanReadable struct {
 
 // OnResult prints the aggregate result.
 func (HumanReadable) OnResult(r Result) {
-	fmt.Printf("Download rate: %f Mb/s, rtt: %.2f, minrtt: %.2f\n",
-		r.Goodput/1e6, float32(r.RTT)/1000, float32(r.MinRTT)/1000)
+	fmt.Printf("%s rate: %f Mb/s, rtt: %.2f, minrtt: %.2f\n",
+		r.Subtest, r.Goodput/1e6, float32(r.RTT)/1000, float32(r.MinRTT)/1000)
 }
 
 // OnStart is called when the stream starts and prints the subtest and server hostname.
@@ -71,8 +71,10 @@ func (HumanReadable) OnSummary(results map[spec.SubtestKind]Result) {
 	fmt.Println()
 	fmt.Printf("Test results:\n")
 	for kind, result := range results {
-		fmt.Printf("  %s rate: %.2f Mb/s, rtt: %.2f ms, minrtt: %.2f ms\n",
+		fmt.Printf("  %s rate: %.2f Mb/s, rtt: %.2fms, minrtt: %.2fms\n",
 			kind, result.Goodput/1e6, float32(result.RTT)/1000, float32(result.MinRTT)/1000)
+		fmt.Printf("    streams: %d, duration: %.2fs, cc algo: %s, byte limit: %d bytes\n",
+			result.Streams, result.Length.Seconds(), result.CongestionControl, result.ByteLimit)
 	}
 }
 

--- a/pkg/client/emitter.go
+++ b/pkg/client/emitter.go
@@ -20,10 +20,12 @@ type Emitter interface {
 	OnResult(Result)
 	// OnError is called on errors.
 	OnError(err error)
-	// OnComplete is called after a stream completes.
-	OnComplete(streamID int, server string)
+	// OnStreamComplete is called after a stream completes.
+	OnStreamComplete(streamID int, server string)
 	// OnDebug is called to print debug information.
 	OnDebug(msg string)
+	// OnSummary is called to print summary information.
+	OnSummary(results map[spec.SubtestKind]Result)
 }
 
 // HumanReadable prints human-readable output to stdout.
@@ -60,9 +62,18 @@ func (HumanReadable) OnError(err error) {
 	}
 }
 
-// OnComplete is called after a stream completes.
-func (HumanReadable) OnComplete(streamID int, server string) {
+// OnStreamComplete is called after a stream completes.
+func (HumanReadable) OnStreamComplete(streamID int, server string) {
 	fmt.Printf("Stream %d complete (server %s)\n", streamID, server)
+}
+
+func (HumanReadable) OnSummary(results map[spec.SubtestKind]Result) {
+	fmt.Println()
+	fmt.Printf("Test results:\n")
+	for kind, result := range results {
+		fmt.Printf("  %s rate: %.2f Mb/s, rtt: %.2f ms, minrtt: %.2f ms\n",
+			kind, result.Goodput/1e6, float32(result.RTT)/1000, float32(result.MinRTT)/1000)
+	}
 }
 
 // OnDebug is called to print debug information.


### PR DESCRIPTION
This PR adds a summary at the end of the measurement and fixes the RTT calculations.

Closes #40

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/45)
<!-- Reviewable:end -->
