### PR TITLE
Fix design document link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The [MSAK design doc (view)][1] describes the throughput1 and latency1 protocols.
 
-[1]: https://docs.google.com/document/d/1OmKXGhQe2mT1gSXI2NT_SxvnKu5OHpBGIYpoWNJwmWA/edit
+[1]: https://docs.google.com/document/d/1OmKXGhQe2mT1gSXI2NT_SxvnKu5OHpBGIYpoWNJwmWA/edit?usp=sharing&resourcekey=0-kCenAC2xuZeAPv_WjEsF3w
 
 * `msak-server` - is the MSAK server
 * `msak-client` - is a full reference client for the throughput1 protocol


### PR DESCRIPTION
The existing link doesn't seem to give access unless the users have edit permissions on the document. This one works even if logged out from any Google account.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/46)
<!-- Reviewable:end -->
