### PR TITLE
Set MaxRuntime to 25s

### DIFF
--- a/pkg/throughput1/spec/spec.go
+++ b/pkg/throughput1/spec/spec.go
@@ -33,7 +33,7 @@ const (
 	UploadPath = "/throughput/v1/upload"
 
 	// MaxRuntime is the maximum runtime of a subtest.
-	MaxRuntime = 15 * time.Second
+	MaxRuntime = 25 * time.Second
 
 	// SecWebSocketProtocol is the value of the Sec-WebSocket-Protocol header.
 	SecWebSocketProtocol = "net.measurementlab.throughput.v1"


### PR DESCRIPTION
This allows the CellWatch test, consisting of a warm-up phase that can last up to 10s + an active test phase that lasts for 10s, to always complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/msak/48)
<!-- Reviewable:end -->
